### PR TITLE
Rename Project to PackageSpec

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,3 +1,3 @@
 {
-    "sources": [ "src" ]
+    "sources": [ "src", "../NuGet.Versioning/src" ]
 }

--- a/src/NuGet.Frameworks/project.json
+++ b/src/NuGet.Frameworks/project.json
@@ -11,6 +11,9 @@
     "frameworks": {
         "net45": { },
         "aspnet50": {
+            "frameworkAssemblies": {
+                "System.Collections": { "version": "", "type": "build" }
+            }
         },
         "aspnetcore50": {
             "dependencies": {

--- a/src/NuGet.Frameworks/project.json
+++ b/src/NuGet.Frameworks/project.json
@@ -10,7 +10,8 @@
     },
     "frameworks": {
         "net45": { },
-        "aspnet50": { },
+        "aspnet50": {
+        },
         "aspnetcore50": {
             "dependencies": {
                 "System.Runtime": "4.0.20-beta-*",

--- a/src/NuGet.ProjectModel/IProjectResolver.cs
+++ b/src/NuGet.ProjectModel/IProjectResolver.cs
@@ -10,6 +10,6 @@ namespace NuGet.ProjectModel
     {
         IEnumerable<string> SearchPaths { get; }
 
-        bool TryResolveProject(string name, out Project project);
+        bool TryResolveProject(string name, out PackageSpec project);
     }
 }

--- a/src/NuGet.ProjectModel/JTokenExtensions.cs
+++ b/src/NuGet.ProjectModel/JTokenExtensions.cs
@@ -33,42 +33,5 @@ namespace NuGet.ProjectModel
 
             return obj.Value<T>();
         }
-        public static IDictionary<string, object> ToDictionary(this JObject obj)
-        {
-            return obj.Properties()
-                .ToDictionary(
-                    p => p.Name,
-                    p => ConvertJsonValue(p.Value));
-        }
-
-        private static object ConvertJsonValue(JToken token)
-        {
-            switch (token.Type)
-            {
-                case JTokenType.Object:
-                    return ((JObject)token).ToDictionary();
-                case JTokenType.Array:
-                    return ((JArray)token).Select(ConvertJsonValue).ToArray();
-                case JTokenType.Integer:
-                    return (long)token;
-                case JTokenType.Float:
-                    return (double)token;
-                case JTokenType.Boolean:
-                    return (bool)token;
-
-                // Dump all the string-derived types that JSON.NET tries to sniff out back to strings
-                case JTokenType.String:
-                case JTokenType.Date:
-                case JTokenType.Bytes:
-                case JTokenType.Guid:
-                case JTokenType.Uri:
-                case JTokenType.TimeSpan:
-                    return (string)token;
-                default:
-                    // This covers BOTH the case where the property value is null
-                    // AND the case where the property value is of unknown type
-                    return null;
-            }
-        }
     }
 }

--- a/src/NuGet.ProjectModel/JTokenExtensions.cs
+++ b/src/NuGet.ProjectModel/JTokenExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 
@@ -31,6 +32,43 @@ namespace NuGet.ProjectModel
             }
 
             return obj.Value<T>();
+        }
+        public static IDictionary<string, object> ToDictionary(this JObject obj)
+        {
+            return obj.Properties()
+                .ToDictionary(
+                    p => p.Name,
+                    p => ConvertJsonValue(p.Value));
+        }
+
+        private static object ConvertJsonValue(JToken token)
+        {
+            switch (token.Type)
+            {
+                case JTokenType.Object:
+                    return ((JObject)token).ToDictionary();
+                case JTokenType.Array:
+                    return ((JArray)token).Select(ConvertJsonValue).ToArray();
+                case JTokenType.Integer:
+                    return (long)token;
+                case JTokenType.Float:
+                    return (double)token;
+                case JTokenType.Boolean:
+                    return (bool)token;
+
+                // Dump all the string-derived types that JSON.NET tries to sniff out back to strings
+                case JTokenType.String:
+                case JTokenType.Date:
+                case JTokenType.Bytes:
+                case JTokenType.Guid:
+                case JTokenType.Uri:
+                case JTokenType.TimeSpan:
+                    return (string)token;
+                default:
+                    // This covers BOTH the case where the property value is null
+                    // AND the case where the property value is of unknown type
+                    return null;
+            }
         }
     }
 }

--- a/src/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -136,15 +136,14 @@ namespace NuGet.ProjectModel
                 }
             }
 
-            // These are broken because NuGet.Versioning is portable or strong-named maybe?
-            //BuildTargetFrameworks(packageSpec, rawPackageSpec);
+            BuildTargetFrameworks(packageSpec, rawPackageSpec);
 
-            //PopulateDependencies(
-            //    packageSpec.FilePath,
-            //    packageSpec.Dependencies,
-            //    rawPackageSpec,
-            //    "dependencies",
-            //    isGacOrFrameworkReference: false);
+            PopulateDependencies(
+                packageSpec.FilePath,
+                packageSpec.Dependencies,
+                rawPackageSpec,
+                "dependencies",
+                isGacOrFrameworkReference: false);
 
             return packageSpec;
         }
@@ -350,15 +349,6 @@ namespace NuGet.ProjectModel
 
         private static NuGetFramework GetFramework(string key)
         {
-            //if (key == "aspnet50")
-            //{
-            //    return new NuGetFramework("Asp.Net", new Version(5, 0));
-            //}
-            //else if (key == "aspnetcore50")
-            //{
-            //    return new NuGetFramework("Asp.NetCore", new Version(5, 0));
-            //}
-
             return NuGetFramework.Parse(key);
         }
 

--- a/src/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -70,7 +70,7 @@ namespace NuGet.ProjectModel
             // Load the raw JSON into the package spec object
             var reader = new JsonTextReader(new StreamReader(stream));
             var rawPackageSpec = JObject.Load(reader);
-            var packageSpec = new PackageSpec(rawPackageSpec.ToDictionary());
+            var packageSpec = new PackageSpec(rawPackageSpec);
 
             // Parse properties we know about
             var version = rawPackageSpec["version"];

--- a/src/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.ProjectModel/PackageSpec.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using NuGet.LibraryModel;
@@ -8,22 +9,28 @@ using NuGet.Versioning;
 
 namespace NuGet.ProjectModel
 {
-    public class Project
+    /// <summary>
+    /// Represents the specification of a package that can be built.
+    /// </summary>
+    public class PackageSpec 
     {
-        public const string ProjectFileName = "project.json";
+        public static readonly string PackageSpecFileName = "project.json";
 
-        public Project()
+        public PackageSpec() : this(new Dictionary<string, object>()) { }
+        public PackageSpec(IDictionary<string, object> rawProperties)
         {
+            Scripts = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase);
             TargetFrameworks = new List<TargetFrameworkInformation>();
+            Properties = rawProperties;
         }
 
-        public string ProjectFilePath { get; set; }
+        public string FilePath { get; set; }
 
         public string ProjectDirectory
         {
             get
             {
-                return Path.GetDirectoryName(ProjectFilePath);
+                return Path.GetDirectoryName(FilePath);
             }
         }
 
@@ -52,7 +59,16 @@ namespace NuGet.ProjectModel
         public string[] Tags { get; set; }
 
         public IList<LibraryDependency> Dependencies { get; set; }
-        
+
+        public IDictionary<string, IEnumerable<string>> Scripts { get; private set; }
+
         public List<TargetFrameworkInformation> TargetFrameworks { get; private set; }
+
+        /// <summary>
+        /// Gets a list of all properties found in the package spec, including
+        /// those not recognized by the parser.
+        /// </summary>
+        public IDictionary<string, object> Properties { get; }
     }
 }
+

--- a/src/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.ProjectModel/PackageSpec.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Newtonsoft.Json.Linq;
 using NuGet.LibraryModel;
 using NuGet.Versioning;
 
@@ -16,8 +17,7 @@ namespace NuGet.ProjectModel
     {
         public static readonly string PackageSpecFileName = "project.json";
 
-        public PackageSpec() : this(new Dictionary<string, object>()) { }
-        public PackageSpec(IDictionary<string, object> rawProperties)
+        public PackageSpec(JObject rawProperties)
         {
             Scripts = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase);
             TargetFrameworks = new List<TargetFrameworkInformation>();
@@ -68,7 +68,8 @@ namespace NuGet.ProjectModel
         /// Gets a list of all properties found in the package spec, including
         /// those not recognized by the parser.
         /// </summary>
-        public IDictionary<string, object> Properties { get; }
+        // TODO: Remove dependency on Newtonsoft.Json here.
+        public JObject Properties { get; }
     }
 }
 

--- a/src/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.ProjectModel/PackageSpec.cs
@@ -26,7 +26,7 @@ namespace NuGet.ProjectModel
 
         public string FilePath { get; set; }
 
-        public string ProjectDirectory
+        public string BaseDirectory
         {
             get
             {

--- a/src/NuGet.ProjectModel/PackageSpecExtensions.cs
+++ b/src/NuGet.ProjectModel/PackageSpecExtensions.cs
@@ -2,9 +2,9 @@
 
 namespace NuGet.ProjectModel
 {
-    public static class ProjectExtensions
+    public static class PackageSpecExtensions
     {
-        public static TargetFrameworkInformation GetTargetFramework(this Project project, NuGetFramework targetFramework)
+        public static TargetFrameworkInformation GetTargetFramework(this PackageSpec project, NuGetFramework targetFramework)
         {
             var frameworkInfo = NuGetFrameworkUtility.GetNearest(project.TargetFrameworks, 
                                                                  targetFramework, 

--- a/src/NuGet.ProjectModel/PackageSpecFormatException.cs
+++ b/src/NuGet.ProjectModel/PackageSpecFormatException.cs
@@ -4,14 +4,14 @@ using Newtonsoft.Json.Linq;
 
 namespace NuGet.ProjectModel
 {
-    public sealed class ProjectFormatException : Exception
+    public sealed class PackageSpecFormatException : Exception
     {
-        public ProjectFormatException(string message) :
+        public PackageSpecFormatException(string message) :
             base(message)
         {
         }
 
-        public ProjectFormatException(string message, Exception innerException) :
+        public PackageSpecFormatException(string message, Exception innerException) :
             base(message, innerException)
         {
 
@@ -21,7 +21,7 @@ namespace NuGet.ProjectModel
         public int Line { get; private set; }
         public int Column { get; private set; }
 
-        private ProjectFormatException WithLineInfo(IJsonLineInfo lineInfo)
+        private PackageSpecFormatException WithLineInfo(IJsonLineInfo lineInfo)
         {
             Line = lineInfo.LineNumber;
             Column = lineInfo.LinePosition;
@@ -29,31 +29,31 @@ namespace NuGet.ProjectModel
             return this;
         }
 
-        public static ProjectFormatException Create(Exception exception, JToken value, string path)
+        public static PackageSpecFormatException Create(Exception exception, JToken value, string path)
         {
             var lineInfo = (IJsonLineInfo)value;
 
-            return new ProjectFormatException(exception.Message, exception)
+            return new PackageSpecFormatException(exception.Message, exception)
             {
                 Path = path
             }
             .WithLineInfo(lineInfo);
         }
 
-        public static ProjectFormatException Create(string message, JToken value, string path)
+        public static PackageSpecFormatException Create(string message, JToken value, string path)
         {
             var lineInfo = (IJsonLineInfo)value;
 
-            return new ProjectFormatException(message)
+            return new PackageSpecFormatException(message)
             {
                 Path = path
             }
             .WithLineInfo(lineInfo);
         }
 
-        internal static ProjectFormatException Create(JsonReaderException exception, string path)
+        internal static PackageSpecFormatException Create(JsonReaderException exception, string path)
         {
-            return new ProjectFormatException(exception.Message, exception)
+            return new PackageSpecFormatException(exception.Message, exception)
             {
                 Path = path,
                 Column = exception.LinePosition,

--- a/src/NuGet.ProjectModel/ProjectReferenceDependencyProvider.cs
+++ b/src/NuGet.ProjectModel/ProjectReferenceDependencyProvider.cs
@@ -36,7 +36,7 @@ namespace NuGet.ProjectModel
         {
             string name = libraryRange.Name;
 
-            Project project;
+            PackageSpec project;
 
             // Can't find a project file with the name so bail
             if (!_projectResolver.TryResolveProject(name, out project))
@@ -103,7 +103,7 @@ namespace NuGet.ProjectModel
                     Version = project.Version,
                     Type = LibraryTypes.Project,
                 },
-                Path = project.ProjectFilePath,
+                Path = project.FilePath,
                 Dependencies = dependencies,
                 Resolved = !unresolved
             };

--- a/src/NuGet.ProjectModel/ProjectResolver.cs
+++ b/src/NuGet.ProjectModel/ProjectResolver.cs
@@ -31,7 +31,7 @@ namespace NuGet.ProjectModel
             }
         }
 
-        public bool TryResolveProject(string name, out Project project)
+        public bool TryResolveProject(string name, out PackageSpec project)
         {
             project = null;
 
@@ -103,7 +103,7 @@ namespace NuGet.ProjectModel
 
         private class ProjectInformation
         {
-            private Project _project;
+            private PackageSpec _project;
             private bool _initialized;
             private object _lockObj = new object();
 
@@ -111,14 +111,14 @@ namespace NuGet.ProjectModel
 
             public string FullPath { get; set; }
 
-            public Project Project
+            public PackageSpec Project
             {
                 get
                 {
                     return LazyInitializer.EnsureInitialized(ref _project, ref _initialized, ref _lockObj, () =>
                     {
-                        Project project;
-                        ProjectReader.TryReadProject(FullPath, out project);
+                        PackageSpec project;
+                        JsonPackageSpecReader.TryReadPackageSpec(FullPath, out project);
                         return project;
                     });
                 }

--- a/src/NuGet.ProjectModel/project.json
+++ b/src/NuGet.ProjectModel/project.json
@@ -9,13 +9,10 @@
 
     "frameworks": {
         "net45": {
-            "frameworkAssemblies": {
-                "System.Runtime": { "version": "", "type": "build" }
-            }
         },
         "aspnet50": {
             "frameworkAssemblies": {
-                "System.Runtime": ""
+                "System.Collections": { "version": "", "type": "build" }
             }
         },
         "aspnetcore50": {


### PR DESCRIPTION
Since `Project` is going to be a K Runtime type. `PackageSpec` is the more general concept of a project.json that can produce a Package. A `Project` will wrap a `PackageSpec` and read additional data from the project.json relating to compilation.