### PR TITLE
allow package spec resolver to actually find projects :)

### DIFF
--- a/src/NuGet.ProjectModel/PackageSpecResolver.cs
+++ b/src/NuGet.ProjectModel/PackageSpecResolver.cs
@@ -11,7 +11,7 @@ namespace NuGet.ProjectModel
     public class PackageSpecResolver : IPackageSpecResolver
     {
         private HashSet<string> _searchPaths = new HashSet<string>();
-        private Dictionary<string, PackageSpecInformation> _projects = new Dictionary<string, PackageSpecInformation>();
+        private Dictionary<string, PackageSpecInformation> _projects = new Dictionary<string, PackageSpecInformation>(StringComparer.OrdinalIgnoreCase);
 
         public PackageSpecResolver(string packageSpecPath)
         {
@@ -72,22 +72,19 @@ namespace NuGet.ProjectModel
 
                 foreach (var projectDirectory in directory.EnumerateDirectories())
                 {
-                    // The name of the folder is the project
-                    _projects[projectDirectory.Name] = new PackageSpecInformation
+                    // Check if there is a project within this directory
+                    var projectFilePath = Path.Combine(projectDirectory.FullName, PackageSpec.PackageSpecFileName);
+                    if (File.Exists(projectFilePath))
                     {
-                        Name = projectDirectory.Name,
-                        FullPath = projectDirectory.FullName
-                    };
+                        // The name of the folder is the project
+                        _projects[projectDirectory.Name] = new PackageSpecInformation
+                        {
+                            Name = projectDirectory.Name,
+                            FullPath = projectFilePath
+                        };
+                    }
                 }
             }
-        }
-
-        public static PackageSpecResolver ForPackageSpecDirectory(string packageSpecDirectory)
-        {
-            var packageSpecFile = Path.Combine(packageSpecDirectory, PackageSpec.PackageSpecFileName);
-            return new PackageSpecResolver(
-                packageSpecFile,
-                ResolveRootDirectory(packageSpecFile));
         }
 
         public static string ResolveRootDirectory(string projectPath)

--- a/src/NuGet.ProjectModel/PackageSpecResolver.cs
+++ b/src/NuGet.ProjectModel/PackageSpecResolver.cs
@@ -11,7 +11,7 @@ namespace NuGet.ProjectModel
     public class PackageSpecResolver : IPackageSpecResolver
     {
         private HashSet<string> _searchPaths = new HashSet<string>();
-        private Dictionary<string, PackageSpecInformation> _projects = new Dictionary<string, PackageSpecInformation>(StringComparer.OrdinalIgnoreCase);
+        private Dictionary<string, PackageSpecInformation> _projects = new Dictionary<string, PackageSpecInformation>();
 
         public PackageSpecResolver(string packageSpecPath)
         {
@@ -72,17 +72,18 @@ namespace NuGet.ProjectModel
 
                 foreach (var projectDirectory in directory.EnumerateDirectories())
                 {
-                    // Check if there is a project within this directory
+                    // Create the path to the project.json file.
                     var projectFilePath = Path.Combine(projectDirectory.FullName, PackageSpec.PackageSpecFileName);
-                    if (File.Exists(projectFilePath))
+                    
+                    // We INTENTIONALLY do not do an exists check here because it requires disk I/O
+                    // Instead, we'll do an exists check when we try to resolve 
+
+                    // The name of the folder is the project
+                    _projects[projectDirectory.Name] = new PackageSpecInformation
                     {
-                        // The name of the folder is the project
-                        _projects[projectDirectory.Name] = new PackageSpecInformation
-                        {
-                            Name = projectDirectory.Name,
-                            FullPath = projectFilePath
-                        };
-                    }
+                        Name = projectDirectory.Name,
+                        FullPath = projectFilePath
+                    };
                 }
             }
         }


### PR DESCRIPTION
The existing resolver couldn't actually load the project.json files because the path provided to PackageSpecInformation was the folder path, but it was then given to JsonPackageSpecReader to read as though it was a file name.