### PR TITLE
add a little more detail to dependency graph dump

### DIFF
--- a/src/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -131,7 +131,7 @@ namespace NuGet.DependencyResolver
 
         public static void Dump<TItem>(this GraphNode<TItem> root, Action<string> write)
         {
-            DumpNode(root, write, level: 0, last: false);
+            DumpNode(root, write, level: 0);
             DumpChildren(root, write, level: 0);
         }
 
@@ -140,23 +140,23 @@ namespace NuGet.DependencyResolver
             var children = root.InnerNodes;
             for(int i = 0; i < children.Count; i++)
             {
-                DumpNode(children[i], write, level + 1, level == 0 && i == (children.Count - 1));
+                DumpNode(children[i], write, level + 1);
                 DumpChildren(children[i], write, level + 1);
             }
         }
 
-        private static void DumpNode<TItem>(GraphNode<TItem> node, Action<string> write, int level, bool last)
+        private static void DumpNode<TItem>(GraphNode<TItem> node, Action<string> write, int level)
         {
             StringBuilder output = new StringBuilder();
             if(level > 0)
             {
-                output.Append(last ? LIGHT_UP_AND_RIGHT : LIGHT_VERTICAL_AND_RIGHT);
+                output.Append(LIGHT_VERTICAL_AND_RIGHT);
                 output.Append(new string(LIGHT_HORIZONTAL, level));
                 output.Append(" ");
             }
 
-            output.Append(node.Key.ToString());
-            
+            output.Append($"{node.Key} ({node.Disposition})");
+
             if(node.Item != null && node.Item.Key != null)
             {
                 output.Append($" => {node.Item.Key.ToString()}");

--- a/src/NuGet.LibraryModel/LibraryIdentity.cs
+++ b/src/NuGet.LibraryModel/LibraryIdentity.cs
@@ -17,7 +17,7 @@ namespace NuGet.LibraryModel
 
         public override string ToString()
         {
-            return Name + " " + Version?.ToString();
+            return Type + "/" + Name + " " + Version?.ToString();
         }
 
         public bool Equals(LibraryIdentity other)


### PR DESCRIPTION
Add a little more detail to the dependency graph dump. Examples below. /cc @davidfowl 

![capture](https://cloud.githubusercontent.com/assets/7574/6453378/221e6a98-c0f2-11e4-9b49-b4aca74cf644.PNG)

![capture](https://cloud.githubusercontent.com/assets/7574/6453388/37890924-c0f2-11e4-9afa-b0d54cea5a95.PNG)
(Note: I haven't hooked up NuGet resolution yet, hence the unresolved nodes in this DTH graph)
