### PR TITLE
NET46 and Core50 Compat rules

### DIFF
--- a/src/NuGet.Frameworks/DefaultFrameworkMappings.cs
+++ b/src/NuGet.Frameworks/DefaultFrameworkMappings.cs
@@ -177,6 +177,11 @@ namespace NuGet.Frameworks
                                                     FrameworkConstants.CommonFrameworks.DnxCore,
                                                     FrameworkConstants.CommonFrameworks.DnxCore50),
 
+                        // core <-> core50
+                        new KeyValuePair<NuGetFramework, NuGetFramework>(
+                                                    FrameworkConstants.CommonFrameworks.Core,
+                                                    FrameworkConstants.CommonFrameworks.Core50),
+
                         // TODO: remove these rules post-RC
                         // aspnet <-> aspnet50
                         new KeyValuePair<NuGetFramework, NuGetFramework>(
@@ -187,16 +192,6 @@ namespace NuGet.Frameworks
                         new KeyValuePair<NuGetFramework, NuGetFramework>(
                                                     FrameworkConstants.CommonFrameworks.AspNetCore,
                                                     FrameworkConstants.CommonFrameworks.AspNetCore50),
-
-                        // aspnet <-> dnx
-                        new KeyValuePair<NuGetFramework, NuGetFramework>(
-                                                    FrameworkConstants.CommonFrameworks.Dnx,
-                                                    FrameworkConstants.CommonFrameworks.AspNet),
-
-                        // aspnetcore <-> dnxcore
-                        new KeyValuePair<NuGetFramework, NuGetFramework>(
-                                                    FrameworkConstants.CommonFrameworks.DnxCore,
-                                                    FrameworkConstants.CommonFrameworks.AspNetCore),
                     };
                 }
 
@@ -272,6 +267,30 @@ namespace NuGet.Frameworks
                             new FrameworkRange(
                                 new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Native, FrameworkConstants.EmptyVersion),
                                 new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Native, FrameworkConstants.EmptyVersion))),
+
+                        // Net46 supports Core50
+                        new OneWayCompatibilityMappingEntry(new FrameworkRange(
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, new Version(4, 6, 0, 0)),
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, FrameworkConstants.MaxVersion)),
+                            new FrameworkRange(
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.CoreCLR, FrameworkConstants.Version5),
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.CoreCLR, FrameworkConstants.Version5))),
+
+                        // DNX supports AspNet
+                        new OneWayCompatibilityMappingEntry(new FrameworkRange(
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Dnx, FrameworkConstants.EmptyVersion),
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Dnx, FrameworkConstants.MaxVersion)),
+                            new FrameworkRange(
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.AspNet, FrameworkConstants.EmptyVersion),
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.AspNet, FrameworkConstants.EmptyVersion))),
+
+                        // DNXCore supports AspNetCore
+                        new OneWayCompatibilityMappingEntry(new FrameworkRange(
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.DnxCore, FrameworkConstants.EmptyVersion),
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.DnxCore, FrameworkConstants.MaxVersion)),
+                            new FrameworkRange(
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.AspNetCore, FrameworkConstants.EmptyVersion),
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.AspNetCore, FrameworkConstants.EmptyVersion))),
                     };
                 }
 

--- a/src/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Frameworks/FrameworkConstants.cs
@@ -8,6 +8,7 @@ namespace NuGet.Frameworks
         public const string GreaterThanOrEqualTo = "\u2265";
         public static readonly Version EmptyVersion = new Version(0, 0, 0, 0);
         public static readonly Version MaxVersion = new Version(Int32.MaxValue, 0, 0, 0);
+        public static readonly Version Version5 = new Version(5, 0, 0, 0);
 
         public static class SpecialIdentifiers
         {
@@ -79,14 +80,17 @@ namespace NuGet.Frameworks
 
             public static readonly NuGetFramework AspNet = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.AspNet, EmptyVersion);
             public static readonly NuGetFramework AspNetCore = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.AspNetCore, EmptyVersion);
-            public static readonly NuGetFramework AspNet50 = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.AspNet, new Version(5, 0, 0, 0));
-            public static readonly NuGetFramework AspNetCore50 = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.AspNetCore, new Version(5, 0, 0, 0));
+            public static readonly NuGetFramework AspNet50 = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.AspNet, Version5);
+            public static readonly NuGetFramework AspNetCore50 = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.AspNetCore, Version5);
 
             public static readonly NuGetFramework Dnx = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Dnx, EmptyVersion);
             public static readonly NuGetFramework Dnx451 = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Dnx, new Version(4, 5, 1, 0));
             public static readonly NuGetFramework Dnx452 = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Dnx, new Version(4, 5, 2, 0));
             public static readonly NuGetFramework DnxCore = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.DnxCore, EmptyVersion);
-            public static readonly NuGetFramework DnxCore50 = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.DnxCore, new Version(5, 0, 0, 0));
+            public static readonly NuGetFramework DnxCore50 = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.DnxCore, Version5);
+
+            public static readonly NuGetFramework Core = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.CoreCLR, EmptyVersion);
+            public static readonly NuGetFramework Core50 = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.CoreCLR, Version5);
         }
 
         // public const RegexOptions RegexFlags = RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture;

--- a/src/NuGet.Frameworks/NuGetFrameworkFactory.cs
+++ b/src/NuGet.Frameworks/NuGetFrameworkFactory.cs
@@ -294,15 +294,23 @@ namespace NuGet.Frameworks
         {
             framework = null;
 
-            if (StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "aspnet") || StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "aspnet50"))
+            if (StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "core50")
+                || StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "core")
+                || StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "core5"))
             {
-                framework = FrameworkConstants.CommonFrameworks.AspNet50;
+                framework = FrameworkConstants.CommonFrameworks.Core50;
             }
-            else if (StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "aspnetcore") || StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "aspnetcore50"))
+            else if (StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "dnx") || StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "dnx451"))
             {
-                framework = FrameworkConstants.CommonFrameworks.AspNetCore50;
+                framework = FrameworkConstants.CommonFrameworks.Dnx451;
             }
-            else if (StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "net40"))
+            else if (StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "dnxcore") 
+                || StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "dnxcore50")
+                || StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "dnxcore5"))
+            {
+                framework = FrameworkConstants.CommonFrameworks.DnxCore50;
+            }
+            else if (StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "net40") || StringComparer.OrdinalIgnoreCase.Equals(frameworkString, "net4"))
             {
                 framework = FrameworkConstants.CommonFrameworks.Net4;
             }

--- a/test/NuGet.Frameworks.Test/FrameworkReducerTests.cs
+++ b/test/NuGet.Frameworks.Test/FrameworkReducerTests.cs
@@ -483,14 +483,6 @@ namespace NuGet.Test
         [InlineData("dnx", "portable-net45+win8")]
         [InlineData("dnx", "portable-win8+net45")]
         [InlineData("dnx", "portable-win8+net45+sl4")]
-        [InlineData("aspnet50", "aspnet50")]
-        [InlineData("aspnet50", "aspnet5")]
-        [InlineData("aspnet50", "aspnet")]
-        [InlineData("aspnet", "aspnet50")]
-        [InlineData("aspnet", "net45")]
-        [InlineData("aspnet", "portable-net45+win8")]
-        [InlineData("aspnet", "portable-win8+net45")]
-        [InlineData("aspnet", "portable-win8+net45+sl4")]
         public void FrameworkReducer_GetNearestDnx(string project, string framework)
         {
             FrameworkReducer reducer = new FrameworkReducer();


### PR DESCRIPTION
Adding CoreCLR compatibility mappings

New rules:
net46 -> core50
dnxcore -> core50

Legacy one way mappings for rc:
dnx -> aspnet
dnxcore -> aspnetcore

Additional rules will be inferred:
dnx46 -> net46 -> core50