### PR TITLE
Fix null ref exception when a dependency project has no version

### DIFF
--- a/src/NuGet.ProjectModel/LockFile.cs
+++ b/src/NuGet.ProjectModel/LockFile.cs
@@ -66,11 +66,20 @@ namespace NuGet.ProjectModel
         // DNU REFACTORING TODO: temp hack to make generated lockfile work with runtime lockfile validation
         private static string RuntimeStyleLibraryRangeToString(LibraryRange libraryRange)
         {
-            var minVersion = libraryRange.VersionRange.MinVersion;
-            var maxVersion = libraryRange.VersionRange.MaxVersion;
             var sb = new System.Text.StringBuilder();
             sb.Append(libraryRange.Name);
-            sb.Append(" >= ");
+            sb.Append(" ");
+
+            if (libraryRange.VersionRange == null)
+            {
+                return sb.ToString();
+            }
+
+            var minVersion = libraryRange.VersionRange.MinVersion;
+            var maxVersion = libraryRange.VersionRange.MaxVersion;
+
+            sb.Append(">= ");
+
             if (libraryRange.VersionRange.IsFloating)
             {
                 sb.Append(libraryRange.VersionRange.Float.ToString());


### PR DESCRIPTION
Although we don't support dependency that has blank version, we don't want null ref exception in this case