### PR TITLE
make compat table cache key more stable

### DIFF
--- a/src/NuGet.Frameworks/CompatibilityProvider.cs
+++ b/src/NuGet.Frameworks/CompatibilityProvider.cs
@@ -2,7 +2,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using HashCombiner = NuGet.Frameworks.HashCodeCombiner;
 
 namespace NuGet.Frameworks
 {
@@ -11,13 +10,13 @@ namespace NuGet.Frameworks
         private readonly IFrameworkNameProvider _mappings;
         private readonly FrameworkExpander _expander;
         private static readonly NuGetFrameworkFullComparer _fullComparer = new NuGetFrameworkFullComparer();
-        private readonly ConcurrentDictionary<int, bool> _cache;
+        private readonly ConcurrentDictionary<Tuple<NuGetFramework, NuGetFramework>, bool> _cache;
 
         public CompatibilityProvider(IFrameworkNameProvider mappings)
         {
             _mappings = mappings;
             _expander = new FrameworkExpander(mappings);
-            _cache = new ConcurrentDictionary<int, bool>();
+            _cache = new ConcurrentDictionary<Tuple<NuGetFramework, NuGetFramework>, bool>();
         }
 
         /// <summary>
@@ -39,12 +38,10 @@ namespace NuGet.Frameworks
             }
 
             // check the cache for a solution
-            int cacheKey = GetCacheKey(target, candidate);
-
-            bool? result = _cache.GetOrAdd(cacheKey, (Func<int, bool>)((key) =>
+            bool? result = _cache.GetOrAdd(Tuple.Create(target, candidate), key =>
             {
                 return IsCompatibleCore(target, candidate) == true;
-            }));
+            });
 
             return result == true;
         }
@@ -204,18 +201,6 @@ namespace NuGet.Frameworks
         private static bool IsVersionCompatible(Version target, Version candidate)
         {
             return candidate == FrameworkConstants.EmptyVersion || candidate <= target;
-        }
-
-        private static int GetCacheKey(NuGetFramework target, NuGetFramework candidate)
-        {
-            HashCombiner combiner = new HashCombiner();
-
-            // create the cache key from the hash codes of both frameworks
-            // the order is important here since compatibility is usually one way
-            combiner.AddObject(target);
-            combiner.AddObject(candidate);
-
-            return combiner.CombinedHash;
         }
 
         /// <summary>


### PR DESCRIPTION
I noticed this while working on my other PR. Hash Codes are not guaranteed to be unique so they shouldn't really be used as cache keys. Tuple implements GetHashCode by combining hashes and Equals by structural equality so it's a perfect drop-in substitute here :).

/cc @emgarten

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nuget/nuget.packaging/28)
<!-- Reviewable:end -->
