### PR TITLE
Runtime Graph support for UAP

### DIFF
--- a/Packaging.sln
+++ b/Packaging.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22710.0
+VisualStudioVersion = 14.0.22815.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{786C83E6-3A7E-4415-AA00-37AA953588A5}"
 EndProject
@@ -48,6 +48,8 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.Packaging.Core.Types", "src\NuGet.Packaging.Core.Types\NuGet.Packaging.Core.Types.xproj", "{46275450-3B62-4E89-8F7E-3FE2EE8513D2}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.Versioning", "..\NuGet.Versioning\src\NuGet.Versioning\NuGet.Versioning.xproj", "{24E62AB7-64E4-4975-9417-883559D1BC19}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.RuntimeModel", "src\NuGet.RuntimeModel\NuGet.RuntimeModel.xproj", "{79FA1E82-C09B-4F6E-B4E0-CF0F8AE5D365}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -131,6 +133,10 @@ Global
 		{24E62AB7-64E4-4975-9417-883559D1BC19}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{24E62AB7-64E4-4975-9417-883559D1BC19}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{24E62AB7-64E4-4975-9417-883559D1BC19}.Release|Any CPU.Build.0 = Release|Any CPU
+		{79FA1E82-C09B-4F6E-B4E0-CF0F8AE5D365}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79FA1E82-C09B-4F6E-B4E0-CF0F8AE5D365}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79FA1E82-C09B-4F6E-B4E0-CF0F8AE5D365}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79FA1E82-C09B-4F6E-B4E0-CF0F8AE5D365}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -154,5 +160,6 @@ Global
 		{CF8E1753-EE98-410F-BB4B-6624B19C6B64} = {42D1FAFB-2A1F-462F-8E4D-C4F8982AD7CB}
 		{002AE92E-01E5-4A38-996B-731A7A048D58} = {42D1FAFB-2A1F-462F-8E4D-C4F8982AD7CB}
 		{46275450-3B62-4E89-8F7E-3FE2EE8513D2} = {42D1FAFB-2A1F-462F-8E4D-C4F8982AD7CB}
+		{79FA1E82-C09B-4F6E-B4E0-CF0F8AE5D365} = {42D1FAFB-2A1F-462F-8E4D-C4F8982AD7CB}
 	EndGlobalSection
 EndGlobal

--- a/src/NuGet.Common/project.json
+++ b/src/NuGet.Common/project.json
@@ -1,24 +1,11 @@
 ﻿{
     "version": "3.0.0-*",
     "shared": "*.cs",
-    "preprocess": "../../compiler/preprocess/*.cs",
     "dependencies": {
     },
 
     "frameworks": {
         "net45": { },
-        "dnx451": {
-            "frameworkAssemblies": {
-                "System.Runtime": { "version": "", "type": "build" },
-                "System.Threading.Tasks": { "version": "", "type": "build" },
-                "System.Text.Encoding": { "version": "", "type": "build" },
-                "System.Linq": { "version": "", "type": "build" }
-            },
-            "dependencies": {
-                "Microsoft.Framework.Runtime.Roslyn.Interfaces": { "version": "1.0.0-*", "type": "build" },
-                "Newtonsoft.Json": { "version": "6.0.4", "type": "build" }
-            }
-        },
         "dnxcore50": {
             "dependencies": {
                 "System.Runtime": "4.0.20-*"

--- a/src/NuGet.ContentModel/ContentQueryDefinition.cs
+++ b/src/NuGet.ContentModel/ContentQueryDefinition.cs
@@ -1,20 +1,31 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace NuGet.ContentModel
 {
+    /// <summary>
+    /// A pattern that can be used to query a set of file paths for items matching a provided criteria.
+    /// </summary>
+    /// <remarks>
+    /// The pattern is defined as a sequence of literal path strings that must match exactly and property references,
+    /// wrapped in {} characters, which are tested for compatibility with the consumer-provided criteria.
+    /// <seealso cref="ContentPropertyDefinition"/>
+    /// </remarks>
     public class ContentPatternDefinition
     {
-        public ContentPatternDefinition()
+        public ContentPatternDefinition(IReadOnlyDictionary<string, ContentPropertyDefinition> properties, IEnumerable<string> groupPatterns, IEnumerable<string> pathPatterns)
         {
-            GroupPatterns = new List<string>();
-            PathPatterns = new List<string>();
-            PropertyDefinitions = new Dictionary<string, ContentPropertyDefinition>();
+            GroupPatterns = groupPatterns.ToList().AsReadOnly(); 
+            PathPatterns = pathPatterns.ToList().AsReadOnly();
+            PropertyDefinitions = properties;
         }
-        public IList<string> GroupPatterns { get; set; }
 
-        public IList<string> PathPatterns { get; set; }
+        public IEnumerable<string> GroupPatterns { get; }
 
-        public IDictionary<string, ContentPropertyDefinition> PropertyDefinitions { get; set; }
+        public IEnumerable<string> PathPatterns { get; }
+
+        public IReadOnlyDictionary<string, ContentPropertyDefinition> PropertyDefinitions { get; set; }
     }
 }

--- a/src/NuGet.ContentModel/Infrastructure/Parser.cs
+++ b/src/NuGet.ContentModel/Infrastructure/Parser.cs
@@ -38,7 +38,7 @@ namespace NuGet.ContentModel.Infrastructure
             }
         }
 
-        public ContentItem Match(string path, IDictionary<string, ContentPropertyDefinition> propertyDefinitions)
+        public ContentItem Match(string path, IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions)
         {
             var item = new ContentItem
             {
@@ -60,7 +60,7 @@ namespace NuGet.ContentModel.Infrastructure
 
         private abstract class Segment
         {
-            internal abstract bool TryMatch(ContentItem item, IDictionary<string, ContentPropertyDefinition> propertyDefinitions, int startIndex, out int endIndex);
+            internal abstract bool TryMatch(ContentItem item, IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions, int startIndex, out int endIndex);
         }
 
         private class LiteralSegment : Segment
@@ -74,7 +74,7 @@ namespace NuGet.ContentModel.Infrastructure
 
             internal override bool TryMatch(
                 ContentItem item,
-                IDictionary<string, ContentPropertyDefinition> propertyDefinitions,
+                IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions,
                 int startIndex,
                 out int endIndex)
             {
@@ -105,7 +105,7 @@ namespace NuGet.ContentModel.Infrastructure
                 _matchOnly = matchOnly;
             }
 
-            internal override bool TryMatch(ContentItem item, IDictionary<string, ContentPropertyDefinition> propertyDefinitions, int startIndex, out int endIndex)
+            internal override bool TryMatch(ContentItem item, IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions, int startIndex, out int endIndex)
             {
                 ContentPropertyDefinition propertyDefinition;
                 if (!propertyDefinitions.TryGetValue(_token, out propertyDefinition))

--- a/src/NuGet.ContentModel/SelectionCriteriaBuilder.cs
+++ b/src/NuGet.ContentModel/SelectionCriteriaBuilder.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NuGet.ContentModel
+{
+    public class SelectionCriteriaBuilder
+    {
+        private IReadOnlyDictionary<string, ContentPropertyDefinition> _propertyDefinitions;
+
+        public SelectionCriteriaBuilder(IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions)
+        {
+            _propertyDefinitions = propertyDefinitions;
+        }
+
+        public virtual SelectionCriteria Criteria { get; } = new SelectionCriteria();
+
+        public virtual SelectionCriteriaEntryBuilder Add
+        {
+            get
+            {
+                var entry = new SelectionCriteriaEntry();
+                Criteria.Entries.Add(entry);
+                return new SelectionCriteriaEntryBuilder(this, entry);
+            }
+        }
+
+        public class SelectionCriteriaEntryBuilder : SelectionCriteriaBuilder
+        {
+            public SelectionCriteriaEntry Entry { get; }
+            public SelectionCriteriaBuilder Builder { get; }
+
+            public SelectionCriteriaEntryBuilder(SelectionCriteriaBuilder builder, SelectionCriteriaEntry entry) : base(builder._propertyDefinitions)
+            {
+                Builder = builder;
+                Entry = entry;
+            }
+            public SelectionCriteriaEntryBuilder this[string key, string value]
+            {
+                get
+                {
+                    ContentPropertyDefinition propertyDefinition;
+                    if (!_propertyDefinitions.TryGetValue(key, out propertyDefinition))
+                    {
+                        throw new Exception("Undefined property used for criteria");
+                    }
+                    if (value == null)
+                    {
+                        Entry.Properties[key] = null;
+                    }
+                    else
+                    {
+                        object valueLookup;
+                        if (propertyDefinition.TryLookup(value, out valueLookup))
+                        {
+                            Entry.Properties[key] = valueLookup;
+                        }
+                        else
+                        {
+                            throw new Exception("Undefined value used for criteria");
+                        }
+                    }
+                    return this;
+                }
+            }
+            public SelectionCriteriaEntryBuilder this[string key, object value]
+            {
+                get
+                {
+                    ContentPropertyDefinition propertyDefinition;
+                    if (!_propertyDefinitions.TryGetValue(key, out propertyDefinition))
+                    {
+                        throw new Exception("Undefined property used for criteria");
+                    }
+                    Entry.Properties[key] = value;
+                    return this;
+                }
+            }
+            public override SelectionCriteriaEntryBuilder Add
+            {
+                get
+                {
+                    return Builder.Add;
+                }
+            }
+            public override SelectionCriteria Criteria
+            {
+                get
+                {
+                    return Builder.Criteria;
+                }
+            }
+        }
+    }
+}

--- a/src/NuGet.ContentModel/project.json
+++ b/src/NuGet.ContentModel/project.json
@@ -5,6 +5,7 @@
         "dnxcore50": {
             "dependencies": {
                 "System.Collections": "4.0.10-beta-*",
+                "System.ObjectModel": "4.0.10-beta-*",
                 "System.IO.FileSystem": "4.0.0-beta-*",
                 "System.Linq": "4.0.0-beta-*",
                 "System.Runtime": "4.0.20-beta-*",

--- a/src/NuGet.ContentModel/project.json
+++ b/src/NuGet.ContentModel/project.json
@@ -1,20 +1,7 @@
 ﻿{
     "version": "3.0.0-*",
-    "preprocess": "../../compiler/preprocess/*.cs",
     "frameworks": {
         "net45": { },
-        "dnx451": {
-            "frameworkAssemblies": {
-                "System.Runtime": { "version": "", "type": "build" },
-                "System.Threading.Tasks": { "version": "", "type": "build" },
-                "System.Text.Encoding": { "version": "", "type": "build" },
-                "System.Linq": { "version": "", "type": "build" }
-            },
-            "dependencies": {
-                "Microsoft.Framework.Runtime.Roslyn.Interfaces": { "version": "1.0.0-*", "type": "build" },
-                "Newtonsoft.Json": { "version": "6.0.4", "type": "build" }
-            }
-        },
         "dnxcore50": {
             "dependencies": {
                 "System.Collections": "4.0.10-beta-*",

--- a/src/NuGet.DependencyResolver.Core/GraphModel/GraphItem.cs
+++ b/src/NuGet.DependencyResolver.Core/GraphModel/GraphItem.cs
@@ -1,10 +1,11 @@
 ﻿using System.Diagnostics;
 using NuGet.LibraryModel;
+using System;
 
 namespace NuGet.DependencyResolver
 {
     [DebuggerDisplay("{Key}")]
-    public class GraphItem<TItem>
+    public class GraphItem<TItem> : IEquatable<GraphItem<TItem>>
     {
         public GraphItem(LibraryIdentity key)
         {
@@ -13,5 +14,20 @@ namespace NuGet.DependencyResolver
 
         public LibraryIdentity Key { get; set; }
         public TItem Data { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as GraphItem<TItem>);
+        }
+
+        public bool Equals(GraphItem<TItem> other)
+        {
+            return other != null && Key.Equals(other.Key);
+        }
+
+        public override int GetHashCode()
+        {
+            return Key.GetHashCode();
+        }
     }
 }

--- a/src/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -8,6 +8,13 @@ namespace NuGet.DependencyResolver
 {
     public static class GraphOperations
     {
+        private enum WalkState
+        {
+            Walking,
+            Rejected,
+            Ambiguous
+        }
+
         public static bool TryResolveConflicts<TItem>(this GraphNode<TItem> root)
         {
             // now we walk the tree as often as it takes to determine 
@@ -46,20 +53,19 @@ namespace NuGet.DependencyResolver
                 //  d1 is rejected, d2 is accepted
                 //  x1 is no longer seen, and z1 is not ambiguous
                 //  z1 is accepted
-
-                root.ForEach("Walking", (node, state) =>
+                root.ForEach(WalkState.Walking, (node, state) =>
                 {
                     if (node.Disposition == Disposition.Rejected)
                     {
-                        return "Rejected";
+                        return WalkState.Rejected;
                     }
 
-                    if (state == "Walking" && tracker.IsDisputed(node.Item))
+                    if (state == WalkState.Walking && tracker.IsDisputed(node.Item))
                     {
-                        return "Ambiguous";
+                        return WalkState.Ambiguous;
                     }
 
-                    if (state == "Ambiguous")
+                    if (state == WalkState.Ambiguous)
                     {
                         tracker.MarkAmbiguous(node.Item);
                     }

--- a/src/NuGet.DependencyResolver.Core/GraphModel/Tracker.cs
+++ b/src/NuGet.DependencyResolver.Core/GraphModel/Tracker.cs
@@ -38,6 +38,8 @@ namespace NuGet.DependencyResolver
             return entry.List.All(known => item.Key.Version >= known.Key.Version);
         }
 
+        public IEnumerable<GraphItem<TItem>> GetDisputes(GraphItem<TItem> item) => GetEntry(item).List;
+
         private Entry GetEntry(GraphItem<TItem> item)
         {
             Entry itemList;

--- a/src/NuGet.DependencyResolver.Core/Providers/IRemoteDependencyProvider.cs
+++ b/src/NuGet.DependencyResolver.Core/Providers/IRemoteDependencyProvider.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading.Tasks;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.RuntimeModel;
 
 namespace NuGet.DependencyResolver
 {
@@ -13,6 +14,7 @@ namespace NuGet.DependencyResolver
         Task<RemoteMatch> FindLibrary(LibraryRange libraryRange, NuGetFramework targetFramework);
         Task<IEnumerable<LibraryDependency>> GetDependencies(RemoteMatch match, NuGetFramework targetFramework);
         Task CopyToAsync(RemoteMatch match, Stream stream);
+        Task<RuntimeGraph> GetRuntimeGraph(RemoteMatch match, NuGetFramework framework);
     }
 
 }

--- a/src/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
+++ b/src/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Threading.Tasks;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.RuntimeModel;
 
 namespace NuGet.DependencyResolver
 {
@@ -49,6 +50,26 @@ namespace NuGet.DependencyResolver
         {
             // We never call this on local providers
             throw new NotImplementedException();
+        }
+
+        public Task<RuntimeGraph> GetRuntimeGraph(RemoteMatch match, NuGetFramework framework)
+        {
+            foreach(var path in _dependencyProvider.GetAttemptedPaths(framework))
+            {
+                var runtimeJsonPath = path
+                    .Replace("{name}.nuspec", "runtime.json")
+                    .Replace("project.json", "runtime.json")
+                    .Replace("{name}", match.Library.Name)
+                    .Replace("{version}", match.Library.Version.ToString());
+
+                // Console.WriteLine("*** {0}", runtimeJsonPath);
+                if (File.Exists(runtimeJsonPath))
+                {
+                    Console.WriteLine("*** READING {0}", runtimeJsonPath);
+                    return Task.FromResult(JsonRuntimeFormat.ReadRuntimeGraph(runtimeJsonPath));
+                }
+            }
+            return Task.FromResult<RuntimeGraph>(null);
         }
     }
 }

--- a/src/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
+++ b/src/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
@@ -65,7 +65,6 @@ namespace NuGet.DependencyResolver
                 // Console.WriteLine("*** {0}", runtimeJsonPath);
                 if (File.Exists(runtimeJsonPath))
                 {
-                    Console.WriteLine("*** READING {0}", runtimeJsonPath);
                     return Task.FromResult(JsonRuntimeFormat.ReadRuntimeGraph(runtimeJsonPath));
                 }
             }

--- a/src/NuGet.DependencyResolver.Core/Remote/RemoteWalkContext.cs
+++ b/src/NuGet.DependencyResolver.Core/Remote/RemoteWalkContext.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using NuGet.RuntimeModel;
 using System.Collections.Generic;
 
 namespace NuGet.DependencyResolver

--- a/src/NuGet.DependencyResolver.Core/project.json
+++ b/src/NuGet.DependencyResolver.Core/project.json
@@ -1,26 +1,14 @@
 ﻿{
-    "version": "3.0.0-*",
-    "preprocess": "../../compiler/preprocess/*.cs",
-    "dependencies": {
-        "NuGet.LibraryModel": "3.0.0-*",
-        "NuGet.Frameworks": "3.0.0-*",
-        "NuGet.Repositories": "3.0.0-*"
-    },
+  "version": "3.0.0-*",
+  "dependencies": {
+    "NuGet.LibraryModel": "3.0.0-*",
+    "NuGet.Frameworks": "3.0.0-*",
+    "NuGet.Repositories": "3.0.0-*",
+    "NuGet.RuntimeModel": "3.0.0-*"
+  },
 
-    "frameworks": {
-        "net45": { },
-        "dnx451": {
-            "frameworkAssemblies": {
-                "System.Runtime": { "version": "", "type": "build" },
-                "System.Threading.Tasks": { "version": "", "type": "build" },
-                "System.Text.Encoding": { "version": "", "type": "build" },
-                "System.Linq": { "version": "", "type": "build" }
-            },
-            "dependencies": {
-                "Microsoft.Framework.Runtime.Roslyn.Interfaces": { "version": "1.0.0-*", "type": "build" },
-                "Newtonsoft.Json": { "version": "6.0.4", "type": "build" }
-            }
-        },
-        "dnxcore50": { }
-    }
+  "frameworks": {
+    "net45": { },
+    "dnxcore50": { }
+  }
 }

--- a/src/NuGet.DependencyResolver/project.json
+++ b/src/NuGet.DependencyResolver/project.json
@@ -1,6 +1,5 @@
 ﻿{
     "version": "3.0.0-*",
-    "preprocess": "../../compiler/preprocess/*.cs",
     "dependencies": {
         "NuGet.Packaging": "3.0.0-*",
         "NuGet.DependencyResolver.Core": "3.0.0-*"
@@ -8,18 +7,6 @@
 
     "frameworks": {
         "net45": { },
-        "dnx451": {
-            "frameworkAssemblies": {
-                "System.Runtime": { "version": "", "type": "build" },
-                "System.Threading.Tasks": { "version": "", "type": "build" },
-                "System.Text.Encoding": { "version": "", "type": "build" },
-                "System.Linq": { "version": "", "type": "build" }
-            },
-            "dependencies": {
-                "Microsoft.Framework.Runtime.Roslyn.Interfaces": { "version": "1.0.0-*", "type": "build" },
-                "Newtonsoft.Json": { "version": "6.0.4", "type": "build" }
-            }
-        },
         "dnxcore50": { }
     }
 }

--- a/src/NuGet.Frameworks/FrameworkExtensions.cs
+++ b/src/NuGet.Frameworks/FrameworkExtensions.cs
@@ -19,9 +19,9 @@ namespace NuGet.Frameworks
         /// <summary>
         /// Return the item with the target framework nearest the project framework
         /// </summary>
-        public static IFrameworkSpecific GetNearest(this IEnumerable<IFrameworkSpecific> items, NuGetFramework projectFramework)
+        public static T GetNearest<T>(this IEnumerable<T> items, NuGetFramework projectFramework) where T: class, IFrameworkSpecific
         {
-            return NuGetFrameworkUtility.GetNearest<IFrameworkSpecific>(items, projectFramework, e => e.TargetFramework);
+            return NuGetFrameworkUtility.GetNearest(items, projectFramework, e => e.TargetFramework);
         }
     }
 }

--- a/src/NuGet.Frameworks/project.json
+++ b/src/NuGet.Frameworks/project.json
@@ -5,24 +5,11 @@
     "copyright": "Copyright Outercurve Foundation. All rights reserved.",
     "projectUrl": "https://github.com/NuGet/NuGet.Packaging/",
     "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Packaging/master/LICENSE",
-    "preprocess": "../../compiler/preprocess/*.cs",
     "dependencies": {
         "NuGet.Versioning": "3.0.0-*"
     },
     "frameworks": {
         "net45": { },
-        "dnx451": {
-            "frameworkAssemblies": {
-                "System.Collections": "",
-                "System.Runtime": { "version": "", "type": "build" },
-                "System.Threading.Tasks": { "version": "", "type": "build" },
-                "System.Text.Encoding": { "version": "", "type": "build" }
-            },
-            "dependencies": {
-                "Microsoft.Framework.Runtime.Roslyn.Interfaces": { "version": "1.0.0-*", "type": "build" },
-                "Newtonsoft.Json": { "version": "6.0.4", "type": "build" }
-            }
-        },
         "dnxcore50": {
             "dependencies": {
                 "System.Runtime": "4.0.20-beta-*",

--- a/src/NuGet.LibraryModel/LibraryIdentity.cs
+++ b/src/NuGet.LibraryModel/LibraryIdentity.cs
@@ -7,7 +7,7 @@ using NuGet.Versioning;
 
 namespace NuGet.LibraryModel
 {
-    public class LibraryIdentity : IEquatable<LibraryIdentity>
+    public class LibraryIdentity : IEquatable<LibraryIdentity>, IComparable<LibraryIdentity>
     {
         public string Name { get; set; }
 
@@ -65,6 +65,37 @@ namespace NuGet.LibraryModel
                 TypeConstraint = library.Type,
                 VersionRange = library.Version == null ? null : new VersionRange(library.Version, new FloatRange(NuGetVersionFloatBehavior.None, library.Version))
             };
+        }
+
+        public int CompareTo(LibraryIdentity other)
+        {
+            int compare = string.Compare(Type, other.Type);
+            if(compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(Name, other.Name);
+            if (compare == 0)
+            {
+                if (Version == null && other.Version == null)
+                {
+                    // NOOP;
+                }
+                else if (Version == null)
+                {
+                    compare = -1;
+                }
+                else if (other.Version == null)
+                {
+                    compare = 1;
+                }
+                else
+                {
+                    compare = Version.CompareTo(other.Version);
+                }
+            }
+            return compare;
         }
     }
 }

--- a/src/NuGet.LibraryModel/project.json
+++ b/src/NuGet.LibraryModel/project.json
@@ -1,24 +1,11 @@
 ﻿{
     "version": "3.0.0-*",
-    "preprocess": "../../compiler/preprocess/*.cs",
     "dependencies": {
         "NuGet.Versioning": "3.0.0-*"
     },
 
     "frameworks": {
         "net45": {
-        },
-        "dnx451": {
-            "frameworkAssemblies": {
-                "System.Runtime": { "version": "", "type": "build" },
-                "System.Threading.Tasks": { "version": "", "type": "build" },
-                "System.Text.Encoding": { "version": "", "type": "build" },
-                "System.Linq": { "version": "", "type": "build" }
-            },
-            "dependencies": {
-                "Microsoft.Framework.Runtime.Roslyn.Interfaces": { "version": "1.0.0-*", "type": "build" },
-                "Newtonsoft.Json": { "version": "6.0.4", "type": "build" }
-            }
         },
         "dnxcore50": {
             "dependencies": {

--- a/src/NuGet.Packaging.Core.Types/project.json
+++ b/src/NuGet.Packaging.Core.Types/project.json
@@ -1,23 +1,10 @@
 ﻿{
     "version": "3.0.0-*",
-    "preprocess": "../../compiler/preprocess/*.cs",
     "dependencies": {
         "NuGet.Frameworks": "3.0.0-*"
     },
     "frameworks": {
         "net45": { },
-        "dnx451": {
-            "frameworkAssemblies": {
-                "System.Collections": "",
-                "System.Runtime": { "version": "", "type": "build" },
-                "System.Threading.Tasks": { "version": "", "type": "build" },
-                "System.Text.Encoding": { "version": "", "type": "build" }
-            },
-            "dependencies": {
-                "Microsoft.Framework.Runtime.Roslyn.Interfaces": { "version": "1.0.0-*", "type": "build" },
-                "Newtonsoft.Json": { "version": "6.0.4", "type": "build" }
-            }
-        },
         "dnxcore50": {
             "dependencies": {
             }

--- a/src/NuGet.Packaging.Core/project.json
+++ b/src/NuGet.Packaging.Core/project.json
@@ -5,7 +5,6 @@
     "copyright": "Copyright Outercurve Foundation. All rights reserved.",
     "projectUrl": "https://github.com/NuGet/NuGet.Packaging/",
     "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Packaging/master/LICENSE",
-    "preprocess": "../../compiler/preprocess/*.cs",
     "dependencies": {
         "NuGet.Versioning": "3.0.0-*",
         "NuGet.Packaging.Core.Types": "3.0.0-*"
@@ -16,21 +15,6 @@
                 "System.Xml": "",
                 "System.Xml.Linq": "",
                 "System.IO.Compression": ""
-            }
-        },
-        "dnx451": {
-            "frameworkAssemblies": {
-                "System.Xml": "",
-                "System.Xml.Linq": "",
-                "System.IO.Compression": "",
-                "System.Collections": "",
-                "System.Runtime": { "version": "", "type": "build" },
-                "System.Threading.Tasks": { "version": "", "type": "build" },
-                "System.Text.Encoding": { "version": "", "type": "build" }
-            },
-            "dependencies": {
-                "Microsoft.Framework.Runtime.Roslyn.Interfaces": { "version": "1.0.0-*", "type": "build" },
-                "Newtonsoft.Json": { "version": "6.0.4", "type": "build" }
             }
         },
         "dnxcore50": {

--- a/src/NuGet.Packaging/project.json
+++ b/src/NuGet.Packaging/project.json
@@ -6,7 +6,6 @@
     "projectUrl": "https://github.com/NuGet/NuGet.Packaging/",
     "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Packaging/master/LICENSE",
     "tags": [ "semver", "semantic versioning" ],
-    "preprocess": "../../compiler/preprocess/*.cs",
     "dependencies": {
         "NuGet.Packaging.Core": "3.0.0-*",
         "NuGet.Frameworks": "3.0.0-*"
@@ -17,20 +16,6 @@
                 "System.Xml": "",
                 "System.Xml.Linq": "",
                 "System.IO.Compression": ""
-            }
-        },
-        "dnx451": {
-            "frameworkAssemblies": {
-                "System.Xml": "",
-                "System.Xml.Linq": "",
-                "System.Collections": "",
-                "System.Runtime": { "version": "", "type": "build" },
-                "System.Threading.Tasks": { "version": "", "type": "build" },
-                "System.Text.Encoding": { "version": "", "type": "build" }
-            },
-            "dependencies": {
-                "Microsoft.Framework.Runtime.Roslyn.Interfaces": { "version": "1.0.0-*", "type": "build" },
-                "Newtonsoft.Json": { "version": "6.0.4", "type": "build" }
             }
         },
         "dnxcore50": {

--- a/src/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json.Linq;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Versioning;
+using NuGet.RuntimeModel;
 
 namespace NuGet.ProjectModel
 {
@@ -98,6 +99,9 @@ namespace NuGet.ProjectModel
                 rawPackageSpec,
                 "dependencies",
                 isGacOrFrameworkReference: false);
+
+            // Read the runtime graph
+            packageSpec.RuntimeGraph = JsonRuntimeFormat.ReadRuntimeGraph(rawPackageSpec);
 
             return packageSpec;
         }

--- a/src/NuGet.ProjectModel/LockFile.cs
+++ b/src/NuGet.ProjectModel/LockFile.cs
@@ -10,11 +10,11 @@ namespace NuGet.ProjectModel
 {
     public class LockFile
     {
-        public bool Islocked { get; set; }
+        public bool IsLocked { get; set; }
         public int Version { get; set; }
-        public IList<ProjectFileDependencyGroup> ProjectFileDependencyGroups { get; set; } =
-            new List<ProjectFileDependencyGroup>();
+        public IList<ProjectFileDependencyGroup> ProjectFileDependencyGroups { get; set; } = new List<ProjectFileDependencyGroup>();
         public IList<LockFileLibrary> Libraries { get; set; } = new List<LockFileLibrary>();
+        public IList<LockFileTarget> Targets { get; set; } = new List<LockFileTarget>();
 
         public bool IsValidForPackageSpec(PackageSpec spec)
         {

--- a/src/NuGet.ProjectModel/LockFileLibrary.cs
+++ b/src/NuGet.ProjectModel/LockFileLibrary.cs
@@ -16,13 +16,44 @@ namespace NuGet.ProjectModel
 
         public bool IsServiceable { get; set; }
 
+        public string Sha512 { get; set; }
+
+        public IList<string> Files { get; set; } = new List<string>();
+
+        // Old stuff
+
         public string Sha { get; set; }
 
         public IList<LockFileFrameworkGroup> FrameworkGroups { get; set; } = new List<LockFileFrameworkGroup>();
-
-        public IList<string> Files { get; set; } = new List<string>();
     }
 
+    public class LockFileTarget
+    {
+        public NuGetFramework TargetFramework { get; set; }
+
+        public string RuntimeIdentifier { get; set; }
+
+        public IList<LockFileTargetLibrary> Libraries { get; set; } = new List<LockFileTargetLibrary>();
+    }
+
+    public class LockFileTargetLibrary
+    {
+        public string Name { get; set; }
+
+        public NuGetVersion Version { get; set; }
+
+        public IList<PackageDependency> Dependencies { get; set; } = new List<PackageDependency>();
+
+        public IList<string> FrameworkAssemblies { get; set; } = new List<string>();
+
+        public IList<string> RuntimeAssemblies { get; set; } = new List<string>();
+
+        public IList<string> CompileTimeAssemblies { get; set; } = new List<string>();
+
+        public IList<string> NativeLibraries { get; set; } = new List<string>();
+    }
+
+    // Old stuff
     public class LockFileFrameworkGroup
     {
         public NuGetFramework TargetFramework { get; set; }
@@ -34,5 +65,7 @@ namespace NuGet.ProjectModel
         public IList<string> RuntimeAssemblies { get; set; } = new List<string>();
 
         public IList<string> CompileTimeAssemblies { get; set; } = new List<string>();
+
+        public IList<string> NativeLibraries { get; set; } = new List<string>();
     }
 }

--- a/src/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.ProjectModel/PackageSpec.cs
@@ -7,6 +7,7 @@ using System.IO;
 using Newtonsoft.Json.Linq;
 using NuGet.LibraryModel;
 using NuGet.Versioning;
+using NuGet.RuntimeModel;
 
 namespace NuGet.ProjectModel
 {
@@ -63,6 +64,8 @@ namespace NuGet.ProjectModel
         public IDictionary<string, IEnumerable<string>> Scripts { get; private set; }
 
         public List<TargetFrameworkInformation> TargetFrameworks { get; private set; }
+
+        public RuntimeGraph RuntimeGraph { get; set; }
 
         /// <summary>
         /// Gets a list of all properties found in the package spec, including

--- a/src/NuGet.ProjectModel/project.json
+++ b/src/NuGet.ProjectModel/project.json
@@ -1,33 +1,21 @@
 ﻿{
-    "version": "3.0.0-*",
-    "preprocess": "../../compiler/preprocess/*.cs",
-    "dependencies": {
-        "Newtonsoft.Json": "6.0.6",
-        "NuGet.LibraryModel": "3.0.0-*",
-        "NuGet.DependencyResolver.Core": "3.0.0-*",
-        "NuGet.Packaging.Core.Types": "3.0.0-*"
-    },
+  "version": "3.0.0-*",
+  "dependencies": {
+    "Newtonsoft.Json": "6.0.6",
+    "NuGet.RuntimeModel": "3.0.0-*",
+    "NuGet.LibraryModel": "3.0.0-*",
+    "NuGet.DependencyResolver.Core": "3.0.0-*",
+    "NuGet.Packaging.Core.Types": "3.0.0-*"
+  },
 
-    "frameworks": {
-        "net45": {
-        },
-        "dnx451": {
-            "frameworkAssemblies": {
-                "System.Runtime": { "version": "", "type": "build" },
-                "System.Threading.Tasks": { "version": "", "type": "build" },
-                "System.Text.Encoding": { "version": "", "type": "build" },
-                "System.Linq": { "version": "", "type": "build" }
-            },
-            "dependencies": {
-                "Microsoft.Framework.Runtime.Roslyn.Interfaces": { "version": "1.0.0-*", "type": "build" },
-                "Newtonsoft.Json": { "version": "6.0.4", "type": "build" }
-            }
-        },
-        "dnxcore50": {
-            "dependencies": {
-                "System.Threading": "4.0.10-*",
-                "System.Dynamic.Runtime": "4.0.10-*"
-            }
-        }
+  "frameworks": {
+    "net45": {
+    },
+    "dnxcore50": {
+      "dependencies": {
+        "System.Threading": "4.0.10-*",
+        "System.Dynamic.Runtime": "4.0.10-*"
+      }
     }
+  }
 }

--- a/src/NuGet.Repositories/project.json
+++ b/src/NuGet.Repositories/project.json
@@ -1,24 +1,11 @@
 ﻿{
     "version": "3.0.0-*",
-    "preprocess": "../../compiler/preprocess/*.cs",
     "dependencies": {
         "NuGet.Versioning": "3.0.0-*"
     },
 
     "frameworks": {
         "net45": { },
-        "dnx451": {
-            "frameworkAssemblies": {
-                "System.Runtime": { "version": "", "type": "build" },
-                "System.Threading.Tasks": { "version": "", "type": "build" },
-                "System.Text.Encoding": { "version": "", "type": "build" },
-                "System.Linq": { "version": "", "type": "build" }
-            },
-            "dependencies": {
-                "Microsoft.Framework.Runtime.Roslyn.Interfaces": { "version": "1.0.0-*", "type": "build" },
-                "Newtonsoft.Json": { "version": "6.0.4", "type": "build" }
-            }
-        },
         "dnxcore50": {
             "dependencies": {
                 "System.IO.FileSystem": "4.0.0-beta-*",

--- a/src/NuGet.RuntimeModel/HashCodeCombiner.cs
+++ b/src/NuGet.RuntimeModel/HashCodeCombiner.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+// Default namespace! Because why not :)
+
+/// <summary>
+/// Hash code creator, based on the original NuGet hash code combiner/ASP hash code combiner implementations, and then slightly improved for usage in C# 6 Expression-bodied members
+/// </summary>
+internal sealed class HashCodeCombiner
+{
+    // seed from String.GetHashCode()
+    private const long Seed = 0x1505L;
+
+    private long _combinedHash;
+
+    private HashCodeCombiner()
+    {
+        _combinedHash = Seed;
+    }
+
+    internal static HashCodeCombiner Start()
+    {
+        return new HashCodeCombiner();
+    }
+
+    internal int CombinedHash
+    {
+        get { return _combinedHash.GetHashCode(); }
+    }
+
+    public static implicit operator int(HashCodeCombiner combiner)
+    {
+        return combiner.CombinedHash;
+    }
+
+    internal HashCodeCombiner AddInt32(int i)
+    {
+        _combinedHash = ((_combinedHash << 5) + _combinedHash) ^ i;
+        return this;
+    }
+
+    internal HashCodeCombiner AddObject(int i)
+    {
+        AddInt32(i);
+        return this;
+    }
+
+    internal HashCodeCombiner AddObject(bool b)
+    {
+        AddInt32(b.GetHashCode());
+        return this;
+    }
+
+    internal HashCodeCombiner AddObject(object o)
+    {
+        if (o != null)
+        {
+            AddInt32(o.GetHashCode());
+        }
+        return this;
+    }
+
+    /// <summary>
+    /// Create a unique hash code for the given set of items
+    /// </summary>
+    internal static int GetHashCode(params object[] objects)
+    {
+        HashCodeCombiner combiner = new HashCodeCombiner();
+
+        foreach (object obj in objects)
+        {
+            combiner.AddObject(obj);
+        }
+
+        return combiner.CombinedHash;
+
+    }
+}

--- a/src/NuGet.RuntimeModel/HashCodeCombiner.cs
+++ b/src/NuGet.RuntimeModel/HashCodeCombiner.cs
@@ -1,80 +1,76 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-// Default namespace! Because why not :)
-
-/// <summary>
-/// Hash code creator, based on the original NuGet hash code combiner/ASP hash code combiner implementations, and then slightly improved for usage in C# 6 Expression-bodied members
-/// </summary>
-internal sealed class HashCodeCombiner
+﻿namespace NuGet.RuntimeModel
 {
-    // seed from String.GetHashCode()
-    private const long Seed = 0x1505L;
-
-    private long _combinedHash;
-
-    private HashCodeCombiner()
-    {
-        _combinedHash = Seed;
-    }
-
-    internal static HashCodeCombiner Start()
-    {
-        return new HashCodeCombiner();
-    }
-
-    internal int CombinedHash
-    {
-        get { return _combinedHash.GetHashCode(); }
-    }
-
-    public static implicit operator int(HashCodeCombiner combiner)
-    {
-        return combiner.CombinedHash;
-    }
-
-    internal HashCodeCombiner AddInt32(int i)
-    {
-        _combinedHash = ((_combinedHash << 5) + _combinedHash) ^ i;
-        return this;
-    }
-
-    internal HashCodeCombiner AddObject(int i)
-    {
-        AddInt32(i);
-        return this;
-    }
-
-    internal HashCodeCombiner AddObject(bool b)
-    {
-        AddInt32(b.GetHashCode());
-        return this;
-    }
-
-    internal HashCodeCombiner AddObject(object o)
-    {
-        if (o != null)
-        {
-            AddInt32(o.GetHashCode());
-        }
-        return this;
-    }
-
     /// <summary>
-    /// Create a unique hash code for the given set of items
+    /// Hash code creator, based on the original NuGet hash code combiner/ASP hash code combiner implementations, and then slightly improved for usage in C# 6 Expression-bodied members
     /// </summary>
-    internal static int GetHashCode(params object[] objects)
+    internal sealed class HashCodeCombiner
     {
-        HashCodeCombiner combiner = new HashCodeCombiner();
+        // seed from String.GetHashCode()
+        private const long Seed = 0x1505L;
 
-        foreach (object obj in objects)
+        private long _combinedHash;
+
+        private HashCodeCombiner()
         {
-            combiner.AddObject(obj);
+            _combinedHash = Seed;
         }
 
-        return combiner.CombinedHash;
+        internal static HashCodeCombiner Start()
+        {
+            return new HashCodeCombiner();
+        }
 
+        internal int CombinedHash
+        {
+            get { return _combinedHash.GetHashCode(); }
+        }
+
+        public static implicit operator int (HashCodeCombiner combiner)
+        {
+            return combiner.CombinedHash;
+        }
+
+        internal HashCodeCombiner AddInt32(int i)
+        {
+            _combinedHash = ((_combinedHash << 5) + _combinedHash) ^ i;
+            return this;
+        }
+
+        internal HashCodeCombiner AddObject(int i)
+        {
+            AddInt32(i);
+            return this;
+        }
+
+        internal HashCodeCombiner AddObject(bool b)
+        {
+            AddInt32(b.GetHashCode());
+            return this;
+        }
+
+        internal HashCodeCombiner AddObject(object o)
+        {
+            if (o != null)
+            {
+                AddInt32(o.GetHashCode());
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Create a unique hash code for the given set of items
+        /// </summary>
+        internal static int GetHashCode(params object[] objects)
+        {
+            HashCodeCombiner combiner = new HashCodeCombiner();
+
+            foreach (object obj in objects)
+            {
+                combiner.AddObject(obj);
+            }
+
+            return combiner.CombinedHash;
+
+        }
     }
 }

--- a/src/NuGet.RuntimeModel/JsonRuntimeFormat.cs
+++ b/src/NuGet.RuntimeModel/JsonRuntimeFormat.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NuGet.Versioning;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace NuGet.RuntimeModel
+{
+    public static class JsonRuntimeFormat
+    {
+        public static RuntimeGraph ReadRuntimeGraph(string filePath)
+        {
+            using (var fileStream = File.OpenRead(filePath))
+            {
+                using (var streamReader = new StreamReader(fileStream))
+                {
+                    return ReadRuntimeGraph(streamReader);
+                }
+            }
+        }
+
+        public static RuntimeGraph ReadRuntimeGraph(TextReader textReader)
+        {
+            using (var jsonReader = new JsonTextReader(textReader))
+            {
+                return ReadRuntimeGraph(JToken.Load(jsonReader));
+            }
+        }
+
+        public static void WriteRuntimeGraph(string filePath, RuntimeGraph runtimeGraph)
+        {
+            using (var fileStream = new FileStream(filePath, FileMode.Create))
+            {
+                using (var textWriter = new StreamWriter(fileStream))
+                {
+                    using (var jsonWriter = new JsonTextWriter(textWriter))
+                    {
+                        jsonWriter.Formatting = Formatting.Indented;
+                        var json = new JObject();
+                        WriteRuntimeGraph(json, runtimeGraph);
+                        json.WriteTo(jsonWriter);
+                    }
+                }
+            }
+        }
+
+        public static RuntimeGraph ReadRuntimeGraph(JToken json)
+        {
+            var graph = new RuntimeGraph();
+            foreach (var runtimeSpec in EachProperty(json["runtimes"]).Select(ReadRuntimeDescription))
+            {
+                graph.Runtimes.Add(runtimeSpec.RuntimeIdentifier, runtimeSpec);
+            }
+            return graph;
+        }
+
+        private static void WriteRuntimeGraph(JObject json, RuntimeGraph runtimeGraph)
+        {
+            var runtimes = new JObject();
+            json["runtimes"] = runtimes;
+            foreach (var x in runtimeGraph.Runtimes.Values)
+            {
+                WriteRuntimeDescription(runtimes, x);
+            }
+        }
+
+        private static void WriteRuntimeDescription(JObject json, RuntimeDescription data)
+        {
+            var value = new JObject();
+            json[data.RuntimeIdentifier] = value;
+            value["#import"] = new JArray(data.InheritedRuntimes.Select(x => new JValue(x)));
+            foreach (var x in data.AdditionalDependencies.Values)
+            {
+                WriteRuntimeDependencySet(value, x);
+            }
+        }
+
+        private static void WriteRuntimeDependencySet(JObject json, RuntimeDependencySet data)
+        {
+            var value = new JObject();
+            json[data.Id] = value;
+            foreach (var x in data.Dependencies.Values)
+            {
+                WritePackageDependency(value, x);
+            }
+        }
+
+        private static void WritePackageDependency(JObject json, RuntimePackageDependency data)
+        {
+            json[data.Id] = new JValue(data.Version);
+        }
+
+        private static RuntimeDescription ReadRuntimeDescription(KeyValuePair<string, JToken> json)
+        {
+            string name = json.Key;
+            IList<string> inheritedRuntimes = new List<string>();
+            IList<RuntimeDependencySet> additionalDependencies = new List<RuntimeDependencySet>();
+            foreach (var property in EachProperty(json.Value))
+            {
+                if (property.Key == "#import")
+                {
+                    var imports = property.Value as JArray;
+                    foreach (var import in imports)
+                    {
+                        inheritedRuntimes.Add(import.Value<string>());
+                    }
+                }
+                else
+                {
+                    var dependency = ReadRuntimeDependencySet(property);
+                    additionalDependencies.Add(dependency);
+                }
+            }
+            return new RuntimeDescription(name, inheritedRuntimes, additionalDependencies);
+        }
+
+        private static RuntimeDependencySet ReadRuntimeDependencySet(KeyValuePair<string, JToken> json)
+        {
+            return new RuntimeDependencySet(
+                json.Key,
+                EachProperty(json.Value).Select(ReadRuntimePackageDependency));
+        }
+
+        private static RuntimePackageDependency ReadRuntimePackageDependency(KeyValuePair<string, JToken> json)
+        {
+            return new RuntimePackageDependency(json.Key, NuGetVersion.Parse(json.Value.Value<string>()));
+        }
+
+        private static IEnumerable<KeyValuePair<string, JToken>> EachProperty(JToken json)
+        {
+            return (json as IEnumerable<KeyValuePair<string, JToken>>)
+                ?? Enumerable.Empty<KeyValuePair<string, JToken>>();
+        }
+
+        private static IEnumerable<KeyValuePair<string, JToken>> EachProperty(JToken json, string defaultPropertyName)
+        {
+            return (json as IEnumerable<KeyValuePair<string, JToken>>)
+                ?? new[] { new KeyValuePair<string, JToken>(defaultPropertyName, json) };
+        }
+
+        private static IEnumerable<JToken> EachArray(JToken json)
+        {
+            return (IEnumerable<JToken>)(json as JArray)
+                ?? new[] { json };
+        }
+
+    }
+}

--- a/src/NuGet.RuntimeModel/NuGet.RuntimeModel.xproj
+++ b/src/NuGet.RuntimeModel/NuGet.RuntimeModel.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>79fa1e82-c09b-4f6e-b4e0-cf0f8ae5d365</ProjectGuid>
+    <RootNamespace>NuGet.RuntimeModel</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/NuGet.RuntimeModel/Properties/AssemblyInfo.cs
+++ b/src/NuGet.RuntimeModel/Properties/AssemblyInfo.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Reflection;
+using System.Resources;
+using System.Runtime.CompilerServices;
+
+[assembly: NeutralResourcesLanguage("en-US")]
+[assembly: CLSCompliant(true)]
+
+// When built on the build server, the NuGet release version is specified by the build.
+// When built locally, the NuGet release version is the values specified in this file.
+#if !FIXED_ASSEMBLY_VERSION
+[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyInformationalVersion("3.0.0-beta")]
+#endif

--- a/src/NuGet.RuntimeModel/RuntimeDependencySet.cs
+++ b/src/NuGet.RuntimeModel/RuntimeDependencySet.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NuGet.RuntimeModel
+{
+    public class RuntimeDependencySet : IEquatable<RuntimeDependencySet>
+    {
+        public string Id { get; }
+        public IDictionary<string, RuntimePackageDependency> Dependencies { get; }
+
+        public RuntimeDependencySet(string id) : this(id, Enumerable.Empty<RuntimePackageDependency>()) { }
+        public RuntimeDependencySet(string id, IEnumerable<RuntimePackageDependency> dependencies)
+        {
+            Id = id;
+            Dependencies = dependencies.ToDictionary(d => d.Id);
+        }
+
+        public bool Equals(RuntimeDependencySet other) => other != null &&
+            string.Equals(other.Id, Id, StringComparison.Ordinal) &&
+            Dependencies.OrderBy(p => p.Key).SequenceEqual(other.Dependencies.OrderBy(p => p.Key));
+
+        public override bool Equals(object obj) => Equals(obj as RuntimeDependencySet);
+
+        public override int GetHashCode() => HashCodeCombiner.Start()
+            .AddObject(Id)
+            .AddObject(Dependencies);
+
+        public void MergeIn(RuntimeDependencySet dependencySet)
+        {
+            if(!string.Equals(dependencySet.Id, Id, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("TODO: Unable to merge dependency sets, they do not have the same package id");
+            }
+
+            // Merge dependencies!
+            foreach(var dependency in dependencySet.Dependencies.Values)
+            {
+                // REVIEW: Overwrite dependencies?
+                if(Dependencies.ContainsKey(dependency.Id))
+                {
+                    throw new InvalidOperationException("TODO: Duplicate runtime dependencies defined for " + dependency.Id);
+                }
+                Dependencies.Add(dependency.Id, dependency);
+            }
+        }
+    }
+}

--- a/src/NuGet.RuntimeModel/RuntimeDescription.cs
+++ b/src/NuGet.RuntimeModel/RuntimeDescription.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NuGet.RuntimeModel
+{
+    public class RuntimeDescription : IEquatable<RuntimeDescription>
+    {
+        private List<string> _inheritedRuntimes;
+        public string RuntimeIdentifier { get; }
+        public IReadOnlyList<string> InheritedRuntimes => _inheritedRuntimes.AsReadOnly();
+        public IDictionary<string, RuntimeDependencySet> AdditionalDependencies { get; }
+
+        public RuntimeDescription(string runtimeIdentifier) : this(runtimeIdentifier, Enumerable.Empty<string>(), Enumerable.Empty<RuntimeDependencySet>()) { }
+        public RuntimeDescription(string runtimeIdentifier, IEnumerable<string> inheritedRuntimes) : this(runtimeIdentifier, inheritedRuntimes, Enumerable.Empty<RuntimeDependencySet>()) { }
+        public RuntimeDescription(string runtimeIdentifier, IEnumerable<RuntimeDependencySet> additionalDependencies) : this(runtimeIdentifier, Enumerable.Empty<string>(), additionalDependencies) { }
+
+        public RuntimeDescription(string runtimeIdentifier, IEnumerable<string> inheritedRuntimes, IEnumerable<RuntimeDependencySet> additionalDependencies)
+        {
+            RuntimeIdentifier = runtimeIdentifier;
+            _inheritedRuntimes = inheritedRuntimes.ToList();
+            AdditionalDependencies = additionalDependencies.ToDictionary(d => d.Id);
+        }
+
+        public bool Equals(RuntimeDescription other) => other != null &&
+            string.Equals(other.RuntimeIdentifier, RuntimeIdentifier, StringComparison.Ordinal) &&
+            InheritedRuntimes.OrderBy(s => s).SequenceEqual(other.InheritedRuntimes.OrderBy(s => s)) &&
+            AdditionalDependencies.OrderBy(p => p.Key).SequenceEqual(other.AdditionalDependencies.OrderBy(p => p.Key));
+
+        /// <summary>
+        /// Merges the content of the other runtime description in to this runtime description
+        /// </summary>
+        /// <param name="other">The other description to merge in to this description</param>
+        public void MergeIn(RuntimeDescription otherRuntime)
+        {
+            if(!string.Equals(otherRuntime.RuntimeIdentifier, RuntimeIdentifier, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("TODO: Unable to merge runtimes, they do not have the same identifier");
+            }
+
+            // Merge #imports
+            if(otherRuntime.InheritedRuntimes.Count != 0)
+            {
+                if (InheritedRuntimes.Count != 0)
+                {
+                    // Can't merge inherited runtimes!
+                    throw new InvalidOperationException("TODO: Cannot merge the '#imports' property of a runtime. Only one runtime.json should define '#imports' for a particular runtime!");
+                }
+
+                // Copy #imports
+                _inheritedRuntimes = new List<string>(otherRuntime.InheritedRuntimes);
+            }
+
+            // Merge dependency sets
+            foreach(var dependencySet in otherRuntime.AdditionalDependencies)
+            {
+                RuntimeDependencySet myDependencySet;
+                if(AdditionalDependencies.TryGetValue(dependencySet.Key, out myDependencySet))
+                {
+                    myDependencySet.MergeIn(dependencySet.Value);
+                }
+                else
+                {
+                    AdditionalDependencies.Add(dependencySet.Key, dependencySet.Value);
+                }
+            }
+        }
+
+        public override bool Equals(object obj) => Equals(obj as RuntimeDescription);
+        public override int GetHashCode() => HashCodeCombiner.Start()
+            .AddObject(RuntimeIdentifier)
+            .AddObject(InheritedRuntimes)
+            .AddObject(AdditionalDependencies);
+    }
+}

--- a/src/NuGet.RuntimeModel/RuntimeGraph.cs
+++ b/src/NuGet.RuntimeModel/RuntimeGraph.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NuGet.RuntimeModel
+{
+    public class RuntimeGraph : IEquatable<RuntimeGraph>
+    {
+        public IDictionary<string, RuntimeDescription> Runtimes { get; }
+
+        public RuntimeGraph()
+        {
+            Runtimes = new Dictionary<string, RuntimeDescription>();
+        }
+
+        public RuntimeGraph(IEnumerable<RuntimeDescription> runtimes)
+        {
+            Runtimes = runtimes.ToDictionary(r => r.RuntimeIdentifier);
+        }
+
+        /// <summary>
+        /// Merges the content of the other runtime graph in to this runtime graph
+        /// </summary>
+        /// <param name="other">The other graph to merge in to this graph</param>
+        public void MergeIn(RuntimeGraph other)
+        {
+            foreach(var otherRuntime in other.Runtimes.Values)
+            {
+                // Check if we already have the runtime defined
+                RuntimeDescription myRuntime;
+                if(Runtimes.TryGetValue(otherRuntime.RuntimeIdentifier, out myRuntime))
+                {
+                    myRuntime.MergeIn(otherRuntime);
+                }
+                else
+                {
+                    Runtimes.Add(otherRuntime.RuntimeIdentifier, otherRuntime);
+                }
+            }
+        }
+
+        public IEnumerable<string> ExpandRuntime(string runtime)
+        {
+            // Could this be faster? Sure! But we can refactor once it works and has tests
+
+            yield return runtime;
+
+            // Try to expand the runtime based on the graph
+            var deduper = new HashSet<string>();
+            var expansions = new List<string>();
+            deduper.Add(runtime);
+            expansions.Add(runtime);
+            for(int i = 0; i < expansions.Count; i++)
+            {
+                // expansions.Count will keep growing as we add items, but thats OK, we want to expand until we stop getting new items
+                RuntimeDescription desc;
+                if(Runtimes.TryGetValue(expansions[i], out desc))
+                {
+                    // Add the inherited runtimes to the list
+                    foreach(var inheritedRuntime in desc.InheritedRuntimes)
+                    {
+                        if (deduper.Add(inheritedRuntime))
+                        {
+                            yield return inheritedRuntime;
+                            expansions.Add(inheritedRuntime);
+                        }
+                    }
+                }
+            }
+
+        }
+
+        public bool Equals(RuntimeGraph other) => other != null && other.Runtimes
+            .OrderBy(pair => pair.Key)
+            .SequenceEqual(other.Runtimes.OrderBy(pair => pair.Key));
+
+        public override bool Equals(object obj) => Equals(obj as RuntimeGraph);
+        public override int GetHashCode() => Runtimes.GetHashCode();
+    }
+}

--- a/src/NuGet.RuntimeModel/RuntimeGraph.cs
+++ b/src/NuGet.RuntimeModel/RuntimeGraph.cs
@@ -81,6 +81,18 @@ namespace NuGet.RuntimeModel
             }
         }
 
+        /// <summary>
+        /// Determines if two runtime identifiers are compatible, based on the import graph
+        /// </summary>
+        /// <param name="criteria">The criteria being tested</param>
+        /// <param name="provided">The value the criteria is being tested against</param>
+        /// <returns>true if an asset for the runtime in <paramref name="provided"/> can be installed in a project targetting <paramref name="criteria"/>, false otherwise</returns>
+        public bool AreCompatible(string criteria, string provided)
+        {
+            // TODO: Cache this!
+            return ExpandRuntime(criteria).Contains(provided);
+        }
+
         public IEnumerable<RuntimePackageDependency> FindRuntimeDependencies(string runtimeName, string packageId)
         {
             // PERF: We could cache this for a particular (runtimeName,packageId) pair.

--- a/src/NuGet.RuntimeModel/RuntimePackageDependency.cs
+++ b/src/NuGet.RuntimeModel/RuntimePackageDependency.cs
@@ -9,12 +9,16 @@ namespace NuGet.RuntimeModel
     public class RuntimePackageDependency
     {
         public string Id { get; }
-        public NuGetVersion Version { get; }
+        public VersionRange VersionRange { get; }
 
-        public RuntimePackageDependency(string id, NuGetVersion version)
+        public RuntimePackageDependency(string id, VersionRange versionRange)
         {
             Id = id;
-            Version = version;
+            VersionRange = versionRange;
         }
+
+        public RuntimePackageDependency Clone() => new RuntimePackageDependency(Id, VersionRange);
+
+        public override string ToString() => $"{Id} {VersionRange}";
     }
 }

--- a/src/NuGet.RuntimeModel/RuntimePackageDependency.cs
+++ b/src/NuGet.RuntimeModel/RuntimePackageDependency.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Versioning;
+
+namespace NuGet.RuntimeModel
+{
+    public class RuntimePackageDependency
+    {
+        public string Id { get; }
+        public NuGetVersion Version { get; }
+
+        public RuntimePackageDependency(string id, NuGetVersion version)
+        {
+            Id = id;
+            Version = version;
+        }
+    }
+}

--- a/src/NuGet.RuntimeModel/project.json
+++ b/src/NuGet.RuntimeModel/project.json
@@ -1,0 +1,26 @@
+﻿{
+    "version": "3.0.0-*",
+
+    "dependencies": {
+        "NuGet.Versioning": "3.0.0-*",
+        "Newtonsoft.Json": "6.0.6"
+    },
+
+    "frameworks": {
+        "net45": {
+            "frameworkAssemblies": {
+                "System.Collections": ""
+            }
+        },
+        "dnxcore50": {
+            "dependencies": {
+                "System.IO.FileSystem": "4.0.0-beta-*",
+                "System.Console": "4.0.0-beta-*",
+                "System.Collections": "4.0.10-beta-*",
+                "System.Linq": "4.0.0-beta-*",
+                "System.Threading": "4.0.10-beta-*",
+                "Microsoft.CSharp": "4.0.0-beta-*"
+            }
+        }
+    }
+}

--- a/test/NuGet.RuntimeModel.Test/JsonRuntimeFormatTests.cs
+++ b/test/NuGet.RuntimeModel.Test/JsonRuntimeFormatTests.cs
@@ -1,0 +1,67 @@
+﻿using NuGet.Versioning;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace NuGet.RuntimeModel.Test
+{
+    public class JsonRuntimeFormatTests
+    {
+        [Theory]
+        [InlineData("{}")]
+        [InlineData("{\"runtimes\":{}}")]
+        public void CanParseEmptyRuntimeJsons(string content)
+        {
+            Assert.Equal(new RuntimeGraph(), ParseRuntimeJsonString(content));
+        }
+
+        [Fact]
+        public void CanParseSimpleRuntimeJson()
+        {
+            const string content = @"
+{
+    ""runtimes"": {
+        ""any"": {},
+        ""win8-x86"": {
+            ""#import"": [
+                ""win8"",
+                ""win7-x86""
+            ],
+            ""Some.Package"": {
+                ""Some.Package.For.win8-x86"": ""4.2""
+            }
+        },
+        ""win8"": {
+            ""#import"": [
+                ""win7""
+            ]
+        }
+    }
+}";
+
+            Assert.Equal(
+                new RuntimeGraph(new []
+                {
+                    new RuntimeDescription("any"),
+                    new RuntimeDescription("win8-x86", new[]
+                        {
+                            "win8",
+                            "win7-x86"
+                        }, new[] {
+                            new RuntimeDependencySet("Some.Package", new [] {
+                                new RuntimePackageDependency("Some.Package.For.win8-x86", new NuGetVersion("4.2"))
+                            })
+                        }),
+                    new RuntimeDescription("win8", new[] { "win7" })
+                }), ParseRuntimeJsonString(content));
+        }
+
+        private RuntimeGraph ParseRuntimeJsonString(string content)
+        {
+            using (var reader = new StringReader(content))
+            {
+                return JsonRuntimeFormat.ReadRuntimeGraph(reader);
+            }
+        }
+    }
+}

--- a/test/NuGet.RuntimeModel.Test/NuGet.RuntimeModel.Test.xproj
+++ b/test/NuGet.RuntimeModel.Test/NuGet.RuntimeModel.Test.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>12e6128c-2ab3-4af9-a00a-d56d09bf24e9</ProjectGuid>
+    <RootNamespace>NuGet.RuntimeModel.Test</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/NuGet.RuntimeModel.Test/RuntimeGraphTests.cs
+++ b/test/NuGet.RuntimeModel.Test/RuntimeGraphTests.cs
@@ -1,0 +1,119 @@
+﻿using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NuGet.RuntimeModel.Test
+{
+    public class RuntimeGraphTests
+    {
+        [Fact]
+        public void MergingInEmptyGraphHasNoEffect()
+        {
+            var graph = new RuntimeGraph(new[] {
+                new RuntimeDescription("any"),
+                new RuntimeDescription("win8", new[] { "any" })
+                });
+            graph.MergeIn(new RuntimeGraph());
+            Assert.Equal(new RuntimeGraph(new[] {
+                new RuntimeDescription("any"),
+                new RuntimeDescription("win8", new[] { "any" })
+                }), graph);
+        }
+
+        [Fact]
+        public void MergingAddsCompletelyNewRuntimes()
+        {
+            var leftGraph = new RuntimeGraph(new[] {
+                new RuntimeDescription("any"),
+                new RuntimeDescription("win8", new[] { "any", "win7" })
+                });
+            var rightGraph = new RuntimeGraph(new[]
+            {
+                new RuntimeDescription("win7")
+            });
+            leftGraph.MergeIn(rightGraph);
+            Assert.Equal(new RuntimeGraph(new[] {
+                new RuntimeDescription("any"),
+                new RuntimeDescription("win8", new[] { "any", "win7" }),
+                new RuntimeDescription("win7")
+                }), leftGraph);
+        }
+
+        [Fact]
+        public void MergingCombinesDependencySetsInRuntimesDefinedInBoth()
+        {
+            var leftGraph = new RuntimeGraph(new[] {
+                new RuntimeDescription("any"),
+                new RuntimeDescription("win8", new[] { "any", "win7" }, new [] {
+                    new RuntimeDependencySet("Foo"),
+                })
+            });
+            var rightGraph = new RuntimeGraph(new[]
+            {
+                new RuntimeDescription("win8", new[] {
+                    new RuntimeDependencySet("Bar")
+                })
+            });
+            leftGraph.MergeIn(rightGraph);
+            Assert.Equal(new RuntimeGraph(new[] {
+                new RuntimeDescription("any"),
+                new RuntimeDescription("win8", new[] { "any", "win7" }, new [] {
+                    new RuntimeDependencySet("Foo"),
+                    new RuntimeDependencySet("Bar")
+                }),
+            }), leftGraph);
+        }
+
+        [Fact]
+        public void MergingCombinesDependenciesInDependencySetsDefinedInBoth()
+        {
+            var leftGraph = new RuntimeGraph(new[] {
+                new RuntimeDescription("any"),
+                new RuntimeDescription("win8", new[] { "any", "win7" }, new [] {
+                    new RuntimeDependencySet("Foo", new [] {
+                        new RuntimePackageDependency("Foo.win8", new NuGetVersion(1, 2, 3))
+                    }),
+                })
+            });
+            var rightGraph = new RuntimeGraph(new[]
+            {
+                new RuntimeDescription("win8", new[] {
+                    new RuntimeDependencySet("Foo", new [] {
+                        new RuntimePackageDependency("Foo.more.win8", new NuGetVersion(4, 5, 6))
+                    }),
+                })
+            });
+            leftGraph.MergeIn(rightGraph);
+            Assert.Equal(new RuntimeGraph(new[] {
+                new RuntimeDescription("any"),
+                new RuntimeDescription("win8", new[] { "any", "win7" }, new [] {
+                    new RuntimeDependencySet("Foo", new [] {
+                        new RuntimePackageDependency("Foo.win8", new NuGetVersion(1, 2, 3)),
+                        new RuntimePackageDependency("Foo.more.win8", new NuGetVersion(4, 5, 6))
+                    }),
+                }),
+            }), leftGraph);
+        }
+
+        [Theory]
+        [InlineData("win7", "win7")]
+        [InlineData("win8", "win8,win7")]
+        [InlineData("win8-x86", "win8-x86,win8,win7-x86,win7")]
+        public void ExpandShouldExpandRuntimeBasedOnGraph(string start, string expanded)
+        {
+            var graph = new RuntimeGraph(new[]
+            {
+                new RuntimeDescription("win8-x86", new [] { "win8", "win7-x86" }),
+                new RuntimeDescription("win8", new [] { "win7" }),
+                new RuntimeDescription("win7-x86", new [] { "win7" }),
+                new RuntimeDescription("win7"),
+            });
+            Assert.Equal(
+                expanded.Split(','),
+                graph.ExpandRuntime(start).ToArray());
+        }
+    }
+}

--- a/test/NuGet.RuntimeModel.Test/project.json
+++ b/test/NuGet.RuntimeModel.Test/project.json
@@ -1,0 +1,14 @@
+﻿{
+    "version": "3.0.0-*",
+    "dependencies": {
+        "NuGet.RuntimeModel": "3.0.0-*",
+        "xunit.runner.aspnet": "2.0.0-aspnet-*"
+    },
+    "commands": {
+        "test": "xunit.runner.aspnet"
+    },
+    "frameworks": {
+        "dnx451": { },
+        "dnxcore50": { }
+    }
+}


### PR DESCRIPTION
This PR adds runtime.json support as well as support for expanding runtime IDs based on the runtime graph. Also overhauled the NuGet.ContentModel types to be immutable (since mutating them would be VERY bad).

Also adds support for version -9997 lock files

/cc @emgarten @davidfowl @pranavkm @yishaigalatzer 